### PR TITLE
use the correct name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup
 setup(
-  name = 'de-helpers',
+  name = 'dehelpers',
   packages = ['dehelpers'],
   version = '0.0.1',
   description = 'Some additional utilities for idp dissemination data engineers to use',


### PR DESCRIPTION
I typed `de-helpers` rather than `dehelpers` in the setup.py, so the install is looking for the wrong thing, this fixes it